### PR TITLE
BR #171 adds the @xml:lang from ab to div[@class='textpart'] (when texparts are in different languages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 __pycache__
 .DS_Store
 EpiDocXSL.xsl
+tests/OxyResults/
+tests/data/source-new/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 .DS_Store
+EpiDocXSL.xsl

--- a/EpiDocXSL.xpr
+++ b/EpiDocXSL.xpr
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="20.0">
+    <meta>
+        <filters directoryPatterns="" filePatterns="EpiDocXSL.xpr" positiveFilePatterns="" showHiddenFiles="false"/>
+        <options/>
+    </meta>
+    <projectTree name="EpiDocXSL.xpr">
+        <folder path="."/>
+    </projectTree>
+</project>

--- a/EpiDocXSL.xpr
+++ b/EpiDocXSL.xpr
@@ -6,5 +6,6 @@
     </meta>
     <projectTree name="EpiDocXSL.xpr">
         <folder path="."/>
+        <folder path="../../Library/Group%20Containers/2E337YPCZY.airmail/Library/Application%20Support/it.bloop.airmail2/Airmail/General/Tmp/"/>
     </projectTree>
 </project>

--- a/htm-teiab.xsl
+++ b/htm-teiab.xsl
@@ -8,13 +8,9 @@
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
       <div class="textpart">
-      	<!-- transfers the  @xml:lang attribute of the ab element to the textpart-->
-      	<!-- a div[@type='textpart'] is created for each ab element, independant of the textpart / ab hierarchical structure -->
-      	
-      	<xsl:if test="@xml:lang">
-      		<!-- Found in htm-tpl-lang.xsl -->
-      		<xsl:call-template name="attr-lang"/>
-      	</xsl:if>
+      	<!-- transfers ab/@xml:lang  to the textpart-->
+      	<!-- Found in htm-tpl-lang.xsl -->
+      	<xsl:call-template name="attr-lang"/>
           <span class="ab">
               <xsl:if test="$parm-leiden-style='iospe'">
                 <xsl:variable name="div-loc">

--- a/htm-teiab.xsl
+++ b/htm-teiab.xsl
@@ -8,7 +8,9 @@
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
       <div class="textpart">
-      	<!-- transfers ab/@xml:lang  to the textpart-->
+      	<!-- transfers the  @xml:lang attribute of the ab element to the textpart-->
+      	<!-- a div[@type='textpart'] is created for each ab element, independant of the textpart / ab hierarchical structure -->
+      	
       	<!-- Found in htm-tpl-lang.xsl -->
       	<xsl:call-template name="attr-lang"/>
           <span class="ab">

--- a/htm-teiab.xsl
+++ b/htm-teiab.xsl
@@ -8,6 +8,8 @@
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
       <div class="textpart">
+      	<!-- Found in htm-tpl-lang.xsl -->
+      	<xsl:call-template name="attr-lang"/>
           <span class="ab">
               <xsl:if test="$parm-leiden-style='iospe'">
                 <xsl:variable name="div-loc">

--- a/htm-teiab.xsl
+++ b/htm-teiab.xsl
@@ -8,6 +8,7 @@
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
       <div class="textpart">
+      	<!-- transfers ab/@xml:lang  to the textpart-->
       	<!-- Found in htm-tpl-lang.xsl -->
       	<xsl:call-template name="attr-lang"/>
           <span class="ab">

--- a/htm-teiab.xsl
+++ b/htm-teiab.xsl
@@ -8,9 +8,13 @@
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
       <div class="textpart">
-      	<!-- transfers ab/@xml:lang  to the textpart-->
-      	<!-- Found in htm-tpl-lang.xsl -->
-      	<xsl:call-template name="attr-lang"/>
+      	<!-- transfers the  @xml:lang attribute of the ab element to the textpart-->
+      	<!-- a div[@type='textpart'] is created for each ab element, independant of the textpart / ab hierarchical structure -->
+      	
+      	<xsl:if test="@xml:lang">
+      		<!-- Found in htm-tpl-lang.xsl -->
+      		<xsl:call-template name="attr-lang"/>
+      	</xsl:if>
           <span class="ab">
               <xsl:if test="$parm-leiden-style='iospe'">
                 <xsl:variable name="div-loc">


### PR DESCRIPTION
Sourceforge ticket: https://sourceforge.net/p/epidoc/bugs/171/ 

The modification just adds a call to the template`attr-lang` that takes the`ab/@xml:lang` and transfers it to the `html div[@class='texpart']`.
The stylesheet doesn't take into account any attribute on `div[@type='texpart']`. I hadn't got at first that the [ GL ](http://www.stoa.org/epidoc/gl/latest/trans-textpart.html) says that there is only one ab per div.


<!-- transfers the  @xml:lang attribute of the ab element to the textpart-->
			<!-- a div[@type='textpart'] is created for each ab element, independant of the textpart / ab hierarchical structure -->
			<xsl:if test="@xml:lang">
				<!-- Found in htm-tpl-lang.xsl -->
				<xsl:call-template name="attr-lang"/>
			</xsl:if>
