### PR TITLE
LTR Space and Gap

### DIFF
--- a/htm-teigap.xsl
+++ b/htm-teigap.xsl
@@ -13,11 +13,11 @@
          <!--     adds a newline character before gap-extent-line in DDbDP unless <lb/> present    -->
          <br/>
       </xsl:if>
-      <span lang="en" class="gap"><xsl:apply-imports/></span>
+      <span dir="ltr" class="gap"><xsl:apply-imports/></span>
   </xsl:template>
   
   <xsl:template match="t:gap">
-    <span lang="en" class="gap"><xsl:apply-imports/></span>
+    <span dir="ltr" class="gap"><xsl:apply-imports/></span>
   </xsl:template>
   
 </xsl:stylesheet>

--- a/htm-teigap.xsl
+++ b/htm-teigap.xsl
@@ -13,11 +13,15 @@
          <!--     adds a newline character before gap-extent-line in DDbDP unless <lb/> present    -->
          <br/>
       </xsl:if>
-      <span dir="ltr" class="gap"><xsl:apply-imports/></span>
+      <xsl:apply-imports/>
   </xsl:template>
   
   <xsl:template match="t:gap">
-    <span dir="ltr" class="gap"><xsl:apply-imports/></span>
+    <xsl:apply-imports/>
+  </xsl:template>
+  
+  <xsl:template name="extent-string-wrapper">
+    <span dir="ltr" class="gap"><xsl:call-template name="extent-string-content"/></span>
   </xsl:template>
   
 </xsl:stylesheet>

--- a/htm-teispace.xsl
+++ b/htm-teispace.xsl
@@ -11,7 +11,7 @@
 
       <xsl:choose>
           <xsl:when test="$parm-leiden-style = 'london'">
-            <i>
+            <i dir="ltr">
                <!-- Found in teispace.xsl -->
                <xsl:call-template name="space-content-1">
                   <xsl:with-param name="vacat" select="$vacat"/>
@@ -20,23 +20,27 @@
          </xsl:when>
           <xsl:when test="$parm-leiden-style = 'panciera'">
             <!-- Found in teispace.xsl -->
-            <xsl:call-template name="space-content-2">
-               <xsl:with-param name="vacat" select="$vacat"/>
-               <xsl:with-param name="extent" select="$extent"/>
-            </xsl:call-template>
+            <span dir="ltr">
+              <xsl:call-template name="space-content-2">
+                <xsl:with-param name="vacat" select="$vacat"/>
+                <xsl:with-param name="extent" select="$extent"/>
+              </xsl:call-template>
+            </span>
          </xsl:when>
          <xsl:otherwise>
             <!-- Found in teispace.xsl -->
-            <xsl:call-template name="space-content-2">
+           <span dir="ltr">
+             <xsl:call-template name="space-content-2">
                <xsl:with-param name="vacat" select="$vacat"/>
                <xsl:with-param name="extent" select="$extent"/>
-            </xsl:call-template>
+             </xsl:call-template>
+           </span>
          </xsl:otherwise>
       </xsl:choose>
    </xsl:template>
 
    <xsl:template name="dip-space">
-      <em>
+      <em dir="ltr">
          <span class="smaller">
             <xsl:call-template name="space-content-1">
                <xsl:with-param name="vacat" select="'vacat '"/>

--- a/htm-teispace.xsl
+++ b/htm-teispace.xsl
@@ -8,7 +8,6 @@
        <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
        <xsl:param name="vacat"/>
       <xsl:param name="extent"/>
-
       <xsl:choose>
           <xsl:when test="$parm-leiden-style = 'london'">
             <i dir="ltr">

--- a/htm-tpl-sqbrackets.xsl
+++ b/htm-tpl-sqbrackets.xsl
@@ -58,7 +58,7 @@
                 <bracket>⟦</bracket>
             </closingbrackets>
         </xsl:variable>
-        <xsl:variable name="regex" select="concat('([^\]])[',string-join($closingadjacentbrackettypes//text(),''),']([',string-join($ignorableThingsBetweenAdjacentBrackets//text(),''),']*)[',string-join($openingadjacentbrackettypes//text(),''),']([^\[])')"/>
+        <xsl:variable name="regex" select="concat('([^\]])[',string-join($closingadjacentbrackettypes//text(),''),']([',string-join($ignorableThingsBetweenAdjacentBrackets//text(),''),']*)[',string-join($openingadjacentbrackettypes//text(),''),']([^\[])?')"/>
         
         <xsl:variable name="current" select="replace(normalize-space(.), $regex, '$1$2$3')" />
         <xsl:variable name="strlength" select="string-length($current)"/>

--- a/htm-tpl-sqbrackets.xsl
+++ b/htm-tpl-sqbrackets.xsl
@@ -58,7 +58,7 @@
                 <bracket>⟦</bracket>
             </closingbrackets>
         </xsl:variable>
-        <xsl:variable name="regex" select="concat('([^\]])[',string-join($closingadjacentbrackettypes//text(),''),']([',string-join($ignorableThingsBetweenAdjacentBrackets//text(),''),']*)[',string-join($openingadjacentbrackettypes//text(),''),']([^\[])?')"/>
+        <xsl:variable name="regex" select="concat('([^\]]?)[',string-join($closingadjacentbrackettypes//text(),''),']([',string-join($ignorableThingsBetweenAdjacentBrackets//text(),''),']*)[',string-join($openingadjacentbrackettypes//text(),''),']([^\[])')"/>
         
         <xsl:variable name="current" select="replace(normalize-space(.), $regex, '$1$2$3')" />
         <xsl:variable name="strlength" select="string-length($current)"/>

--- a/htm-tpl-sqbrackets.xsl
+++ b/htm-tpl-sqbrackets.xsl
@@ -58,7 +58,7 @@
                 <bracket>⟦</bracket>
             </closingbrackets>
         </xsl:variable>
-        <xsl:variable name="regex" select="concat('([^\]]?)[',string-join($closingadjacentbrackettypes//text(),''),']([',string-join($ignorableThingsBetweenAdjacentBrackets//text(),''),']*)[',string-join($openingadjacentbrackettypes//text(),''),']([^\[])')"/>
+        <xsl:variable name="regex" select="concat('([^\]]?)[',string-join($closingadjacentbrackettypes//text(),''),']([',string-join($ignorableThingsBetweenAdjacentBrackets//text(),''),']*)[',string-join($openingadjacentbrackettypes//text(),''),']([^\[]?)')"/>
         
         <xsl:variable name="current" select="replace(normalize-space(.), $regex, '$1$2$3')" />
         <xsl:variable name="strlength" select="string-length($current)"/>

--- a/teigap.xsl
+++ b/teigap.xsl
@@ -212,12 +212,21 @@
    </xsl:template>
 
 
-   <xsl:template name="extent-string">
+  <xsl:template name="extent-string">
+    <xsl:param name="parm-edition-type" tunnel="yes" required="no"/>
+    <xsl:param name="parm-leiden-style" tunnel="yes" required="no"/>
+    <xsl:param name="parm-edn-structure" tunnel="yes" required="no"/> 
+    <!-- Found in htm|txt-teigap.xsl This allows, e.g. setting a text direction on the content. -->
+    <xsl:call-template name="extent-string-wrapper"/>    
+  </xsl:template>
+
+   <xsl:template name="extent-string-content">
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"/>
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"/>
       <xsl:param name="parm-edn-structure" tunnel="yes" required="no"/> <!-- added for creta -->
       <xsl:variable name="cur-dot" select="EDF:dotchar($parm-leiden-style,@reason)"/>
       <xsl:variable name="cur-max" select="EDF:dotmax($parm-leiden-style)"/>
+     
       <!-- Precision of <gap> defined -->
       <xsl:variable name="circa">
          <xsl:choose>
@@ -250,7 +259,7 @@
                      </xsl:when>
                      <!-- other reason illegible and lost/chars caught in the otherwise -->
                      <xsl:otherwise>
-                        <xsl:text> -ca.?- </xsl:text>
+                        <xsl:text>&#x2066; -ca.?- &#x2069;</xsl:text>
                      </xsl:otherwise>
                   </xsl:choose>
                </xsl:when>
@@ -379,7 +388,7 @@
                         </xsl:call-template>
                      </xsl:when>
                      <xsl:otherwise>
-                        <xsl:text> - - - </xsl:text>
+                        <xsl:text>&#x2066; - - - &#x2069;</xsl:text>
                      </xsl:otherwise>
                   </xsl:choose>
                </xsl:otherwise>
@@ -518,7 +527,7 @@
                   </xsl:choose>
                </xsl:when>
                <xsl:otherwise>
-                  <xsl:text> - - - - - - - - - - </xsl:text>
+                  <xsl:text>&#x2066; - - - - - - - - - - &#x2069;</xsl:text>
                </xsl:otherwise>
             </xsl:choose>
          </xsl:when>

--- a/teigap.xsl
+++ b/teigap.xsl
@@ -259,7 +259,7 @@
                      </xsl:when>
                      <!-- other reason illegible and lost/chars caught in the otherwise -->
                      <xsl:otherwise>
-                        <xsl:text>&#x2066; -ca.?- &#x2069;</xsl:text>
+                        <xsl:text>&#x2066;&#x0A;-ca.?-&#x0A;&#x2069;</xsl:text>
                      </xsl:otherwise>
                   </xsl:choose>
                </xsl:when>

--- a/teispace.xsl
+++ b/teispace.xsl
@@ -47,41 +47,46 @@
          <xsl:otherwise>
             <xsl:choose>
                <xsl:when test="($parm-leiden-style = ('ddbdp','dclp','sammelbuch'))">
-                  <xsl:text> vac. </xsl:text>
-                  <xsl:choose>
+                 <xsl:variable name="content">
+                   <xsl:text>&#x2066; vac. </xsl:text>
+                   <xsl:choose>
                      <xsl:when test="@quantity">
-                        <xsl:if test="@precision='low'">
-                           <xsl:text>ca. </xsl:text>
-                        </xsl:if>
-                        <xsl:value-of select="@quantity"/>
+                       <xsl:if test="@precision='low'">
+                         <xsl:text>ca. </xsl:text>
+                       </xsl:if>
+                       <xsl:value-of select="@quantity"/>
                      </xsl:when>
                      <xsl:when test="@atLeast and @atMost">
-                        <xsl:value-of select="@atLeast"/>
-                        <xsl:text>-</xsl:text>
-                        <xsl:value-of select="@atMost"/>
+                       <xsl:value-of select="@atLeast"/>
+                       <xsl:text>-</xsl:text>
+                       <xsl:value-of select="@atMost"/>
                      </xsl:when>
                      <xsl:when test="@atLeast ">
-                        <xsl:text>&#x2265;</xsl:text>
-                        <xsl:value-of select="@atLeast"/>
+                       <xsl:text>&#x2265;</xsl:text>
+                       <xsl:value-of select="@atLeast"/>
                      </xsl:when>
                      <xsl:when test="@atMost ">
-                        <xsl:text>&#x2264;</xsl:text>
-                        <xsl:value-of select="@atMost"/>
+                       <xsl:text>&#x2264;</xsl:text>
+                       <xsl:value-of select="@atMost"/>
                      </xsl:when>
                      <xsl:otherwise>
-                        <xsl:text>?</xsl:text>
+                       <xsl:text>? </xsl:text>
                      </xsl:otherwise>
-                  </xsl:choose>
-                  <xsl:if test="@unit='line'">
-                        <xsl:text> line</xsl:text>
-                        <xsl:if test="@quantity > 1 or @extent='unknown' or @atLeast or @atMost">
-                           <xsl:text>s</xsl:text>
-                        </xsl:if>
+                   </xsl:choose>
+                   <xsl:if test="@unit='line'">
+                     <xsl:text> line</xsl:text>
+                     <xsl:if test="@quantity > 1 or @extent='unknown' or @atLeast or @atMost">
+                       <xsl:text>s</xsl:text>
                      </xsl:if>
-                  
-                  <xsl:if test="child::t:certainty[@match='..']">
-                     <xsl:text>(?)</xsl:text>
-                  </xsl:if>
+                   </xsl:if>
+                   <xsl:if test="child::t:certainty[@match='..']">
+                     <xsl:text>(?) </xsl:text>
+                   </xsl:if>
+                   <xsl:text>&#x2069;</xsl:text>
+                 </xsl:variable>
+                 <xsl:call-template name="space-content">
+                   <xsl:with-param name="vacat" select="$content"/>
+                 </xsl:call-template>
                </xsl:when>
                
                 <xsl:when test="$parm-leiden-style='london'">

--- a/txt-teigap.xsl
+++ b/txt-teigap.xsl
@@ -16,7 +16,7 @@
   </xsl:template>
   
   <xsl:template name="extent-string-wrapper">
-    <xsl:text></xsl:text><xsl:apply-imports/><xsl:text></xsl:text>
+    <xsl:apply-imports/>
   </xsl:template>
   
 </xsl:stylesheet>

--- a/txt-teigap.xsl
+++ b/txt-teigap.xsl
@@ -15,4 +15,8 @@
       <xsl:apply-imports/>
   </xsl:template>
   
+  <xsl:template name="extent-string-wrapper">
+    <xsl:text>&#2066;</xsl:text><xsl:apply-imports/><xsl:text>&#2069;</xsl:text>
+  </xsl:template>
+  
 </xsl:stylesheet>

--- a/txt-teigap.xsl
+++ b/txt-teigap.xsl
@@ -16,7 +16,7 @@
   </xsl:template>
   
   <xsl:template name="extent-string-wrapper">
-    <xsl:text>&#2066;</xsl:text><xsl:apply-imports/><xsl:text>&#2069;</xsl:text>
+    <xsl:text></xsl:text><xsl:apply-imports/><xsl:text></xsl:text>
   </xsl:template>
   
 </xsl:stylesheet>


### PR DESCRIPTION
This attempts to fix some problems with text directionality in the output of `<space>` and `<gap>` when embedded in RTL text. Specifically, it handles printing only the content of the output LTR without affecting the brackets, which should take their orientation from the surrounding text. This is particularly significant for `<gap>` adjacent to `<supplied>`. where the brackets can end up looking mismatched.
