### PR TITLE
add missing 't:' prefix to template

### DIFF
--- a/teimilestone.xsl
+++ b/teimilestone.xsl
@@ -7,11 +7,11 @@
 
   <xsl:template match="t:milestone[@unit='block' or @unit='fragment']">
      <!-- adds pipe for block, flanked by spaces if not within word -->
-      <xsl:if test="not(ancestor::w)">
+      <xsl:if test="not(ancestor::t:w)">
          <xsl:text> </xsl:text>
       </xsl:if>
       <xsl:text>|</xsl:text>
-      <xsl:if test="not(ancestor::w)">
+      <xsl:if test="not(ancestor::t:w)">
          <xsl:text> </xsl:text>
       </xsl:if>
   </xsl:template>


### PR DESCRIPTION
The test on the ancestor `w` doesn't work because of the missing 't:' prefix in the template. (the pipe representing the block or fragment will not be flanked by space if inside a word...