### PR TITLE
fix SF Bugs #183 default transformation for milestones

### DIFF
--- a/htm-teibibl.xsl
+++ b/htm-teibibl.xsl
@@ -2,6 +2,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
 	xmlns:t="http://www.tei-c.org/ns/1.0" xmlns:f="http://example.com/ns/functions"
 	xmlns:html="http://www.w3.org/1999/html" exclude-result-prefixes="t f" version="2.0" xmlns:fn="http://www.w3.org/2005/xpath-functions">
+	<xsl:import href="htm-teilistbiblandbibl.xsl"/>
 	<!--
 
 Pietro notes on 14/8/2015 work on this template, from mail to Gabriel.
@@ -263,7 +264,8 @@ bibliography. All examples only cater for book and article.
 			</xsl:when>
 			<xsl:otherwise>
 				<!-- This applyes other templates and does not call the zotero api -->
-				<xsl:apply-templates/>
+				<!--<xsl:apply-templates/>-->
+				<xsl:apply-imports/> <!-- so that the templates in 'htm-teilistbiblandbibl.xsl are applied (li aroub bibl elements) -->
 			</xsl:otherwise>
 		</xsl:choose>
 	</xsl:template>

--- a/htm-teimilestone.xsl
+++ b/htm-teimilestone.xsl
@@ -68,8 +68,18 @@
              <xsl:text>|</xsl:text>
           </xsl:when>
           <xsl:otherwise>
-             <br/>
-             <xsl:value-of select="@rend"/>
+             <!-- same as @unit='fragment' or @unit='block' -->
+             <!-- adds pipe for block, flanked by spaces if not within word, and with @n as exposant if exists -->
+             <xsl:if test="not(ancestor::t:w)">
+                <xsl:text> </xsl:text>
+             </xsl:if>
+             <xsl:text>|</xsl:text>
+             <xsl:if test="@n">
+                <sup><xsl:value-of select="@n"/></sup>
+             </xsl:if>  
+             <xsl:if test="not(ancestor::t:w)">
+                <xsl:text> </xsl:text>
+             </xsl:if>
           </xsl:otherwise>
        </xsl:choose>
    </xsl:template>

--- a/teimilestone.xsl
+++ b/teimilestone.xsl
@@ -6,11 +6,14 @@
   <!-- General template in [htm|txt]teimilestone.xsl -->
 
   <xsl:template match="t:milestone[@unit='block' or @unit='fragment']">
-     <!-- adds pipe for block, flanked by spaces if not within word -->
+     <!-- adds pipe for block, flanked by spaces if not within word, and with @n as exposant if exists -->
       <xsl:if test="not(ancestor::t:w)">
          <xsl:text> </xsl:text>
       </xsl:if>
       <xsl:text>|</xsl:text>
+     <xsl:if test="@n">
+        <sup><xsl:value-of select="@n"/></sup>
+     </xsl:if>  
       <xsl:if test="not(ancestor::t:w)">
          <xsl:text> </xsl:text>
       </xsl:if>

--- a/tests/data/expected/ex-milestones-default.html
+++ b/tests/data/expected/ex-milestones-default.html
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html>
+    <head>
+        <title>title of document</title>
+        <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+        <link rel="stylesheet" type="text/css" media="screen, projection" href="../xsl/global.css"
+         />
+    </head>
+    <body>
+        <div id="edition" lang="en">
+            <div class="textpart" lang="en">
+                <span class="ab">
+                    <a id="al1"><!--0--></a>ex. 1 (GL): – abc |<sup>23</sup> def <br id="al2" />ex.
+                    2 (GL): – abc |<sup>24</sup> def <br id="al3" />ex. 3 (fragment) – abc | def <br
+                        id="al4" />ex. 4 (bloc) – abc | def <br id="al5" /><span class="linenumber"
+                        >5</span>ex. 5 (unnumbered) – abc | def <br id="al6" />ex. 6 (fragment with
+                    @n) – abc |<sup>2</sup> def <br id="al7" />ex. 7 (inword fragment) –
+                        abc|<sup>1</sup>def <br id="al8" />ex. 8 (inword block) –
+                    abc|<sup>1</sup>def </span>
+            </div>
+        </div>
+        <div id="apparatus">
+            <h4>Apparatus criticus</h4>
+            <p> 
+            <p>external apparatus criticus (if applicable)</p>
+        </div>
+        <div id="translation">
+            <h2> translation</h2>
+            <p>translation(s)</p>
+        </div>
+        <div id="commentary">
+            <h2>commentary</h2>
+            <p>commentary</p>
+        </div>
+        <div id="bibliography">
+            <h2>bibliography</h2>
+            <p>bibliography of previous editions, discussion, etc.</p>
+        </div>
+        <div id="license"></div>
+    </body>
+</html>

--- a/tests/data/source/ex-milestones.xml
+++ b/tests/data/source/ex-milestones.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" schematypens="http://relaxng.org/ns/structure/1.0"?>
+<?xml-model href="https://epidoc.stoa.org/schema/latest/tei-epidoc.rng" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0" xml:space="preserve" xml:lang="en">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>title of document</title>
+            </titleStmt>
+            <publicationStmt>
+                <authority></authority>
+                <idno type="filename"></idno>
+            </publicationStmt>
+            <sourceDesc>
+                <msDesc>
+                    <msIdentifier>
+                        <repository>museum/archive</repository>
+                        <idno>inventory number</idno>
+                    </msIdentifier>
+                    <physDesc>
+                        <objectDesc>
+                            <supportDesc>
+                                <support>description of object/monument (likely to include <material/>
+                                    and <objectType/> information, <dimensions/>, etc.)</support>
+                            </supportDesc>
+                            <layoutDesc>
+                                <layout>description of text field/campus</layout>
+                            </layoutDesc>
+                        </objectDesc>
+                        <handDesc>
+                            <handNote>description of letters, possibly including <height>letter-heights</height>
+                            </handNote>
+                        </handDesc>
+                    </physDesc>
+                    <history>
+                        <origin>
+                            <origPlace>Place of origin</origPlace>
+                            <origDate>Date of origin</origDate>
+                        </origin>
+                        <provenance type="found"> Findspot and circumstances/context
+                        </provenance>
+                        <provenance type="observed">Modern location(s) (if different from repository, above)
+                        </provenance>
+                    </history>
+                </msDesc>
+            </sourceDesc>
+        </fileDesc>
+    </teiHeader>
+    <!--<facsimile>
+        <graphic url="photograph of text or monument"/>
+    </facsimile>-->
+    <text>
+        <body>
+            <div type="edition" xml:space="preserve">
+                <ab>
+                    <lb n="1"/>ex. 1 (GL): – abc<milestone n="23" ed="La" unit="Dreissiger"/>def
+                    <lb n="2"/>ex. 2 (GL): –  abc<milestone n="24" ed="AV" unit="verse"/>def
+                    <lb n="3"/>ex. 3 (fragment) – abc<milestone unit="fragment"/>def
+                    <lb n="4"/>ex. 4 (bloc) – abc<milestone unit="block"/>def
+                    <lb n="5"/>ex. 5 (unnumbered) – abc<milestone unit="unnumbered"/>def
+                    <lb n="6"/>ex. 6 (fragment with @n) – abc<milestone unit="fragment" n="2"/>def
+                    <lb n="7"/>ex. 7 (inword fragment) – <w>abc<milestone unit="fragment" n="1"/>def</w>
+                    <lb n="8"/>ex. 8 (inword block) – <w>abc<milestone unit="block" n="1"/>def</w>
+                </ab>
+            </div>
+            <div type="apparatus">
+                <p>external apparatus criticus (if applicable)</p>
+            </div>
+            <div type="translation">
+                <p>translation(s)</p>
+            </div>
+            <div type="commentary">
+                <p>commentary</p>
+            </div>
+            <div type="bibliography">
+                <p>bibliography of previous editions, discussion, etc.</p>
+            </div>
+        </body>
+    </text>
+</TEI>


### PR DESCRIPTION
Fix for milestone default behavior -- see **SF Bugs #183**
Added 1 test file 'ex-milestones.xml'  in `tests/data/source` and one result in `tests/data/expected` as 'ex-milestones.html'

Warning: the display is the same for @unit='fragment' or @unit='block' or default.

### Html result before fix: 
@n not rendered and a `<br/>` is inserted... 

![Capture d’écran 2024-03-27 à 11 50 43](https://github.com/EpiDoc/Stylesheets/assets/6703185/286f52e9-5cbf-4f0a-8b40-62deea5c4c69)

### Html result after fix: 
![Capture d’écran 2024-03-27 à 12 08 14](https://github.com/EpiDoc/Stylesheets/assets/6703185/5c518144-f493-48ca-9f11-e721b7d32214)
