### PR TITLE
Allow bibliography path and link URL to be configured

### DIFF
--- a/global-parameters.xml
+++ b/global-parameters.xml
@@ -82,9 +82,34 @@
     <value>zotero</value> <!--looks at the api and renders the html from there-->
   </parameter>
   
+  <parameter> <!--base directory for authority files. Defaults to {user.dir}/webapps/ROOT/content/xml/authority/ in EFES if not set.-->
+    <name>authority-dir</name>
+    <value/>
+  </parameter>
+
   <parameter> <!--path to local TEI XML bibliography if this is the bibliography used-->
     <name>localbibl</name>
     <value>../BIBLIOGRAPHY.xml</value>
+  </parameter>
+
+  <parameter> <!--path to symbols authority file. Defaults to {authority-dir}/symbols.xml if not set.-->
+    <name>symbols-file</name>
+    <value/>
+  </parameter>
+
+  <parameter> <!--path to places authority file. Defaults to {authority-dir}/places.xml if not set.-->
+    <name>places-file</name>
+    <value/>
+  </parameter>
+
+  <parameter> <!--path to institution authority file. Defaults to {authority-dir}/institution.xml if not set.-->
+    <name>institutions-file</name>
+    <value/>
+  </parameter>
+
+  <parameter> <!--URL template for bibliography links. $1 is replaced by the entry ID.-->
+    <name>bib-link-template</name>
+    <value>../concordance/bibliography/$1.html</value>
   </parameter>
   
   <parameter> if the zotero bibliography is used, select whether it is a group library or a user's library

--- a/global-varsandparams.xsl
+++ b/global-varsandparams.xsl
@@ -38,9 +38,13 @@
                         select="document($param-file)//parameter[name = 'js-dir']/value"/>
             <xsl:param name="bibliography"
                         select="document($param-file)//parameter[name = 'bibliography']/value[@on = 'yes']"/>
+            <xsl:variable name="default-bibloc"
+                        select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/bibliography.xml')"/>
             <xsl:param name="localbibl"
-                        select="document($param-file)//parameter[name = 'localbibl']/value"/>
-            <xsl:param name="ZoteroUorG" 
+                        select="(document($param-file)//parameter[name = 'localbibl']/value[. != ''], $default-bibloc)[1]"/>
+            <!-- URL template for bibliography links. $1 is replaced by the bibliography entry ID. -->
+            <xsl:param name="bib-link-template" select="'../concordance/bibliography/$1.html'"/>
+            <xsl:param name="ZoteroUorG"
                         select="document($param-file)//parameter[name = 'ZoteroUorG']/value[@on = 'yes']"/>
             <xsl:param name="ZoteroKey"
                         select="document($param-file)//parameter[name = 'ZoteroKey']/value[@on = 'yes']"/>

--- a/global-varsandparams.xsl
+++ b/global-varsandparams.xsl
@@ -38,12 +38,27 @@
                         select="document($param-file)//parameter[name = 'js-dir']/value"/>
             <xsl:param name="bibliography"
                         select="document($param-file)//parameter[name = 'bibliography']/value[@on = 'yes']"/>
-            <xsl:variable name="default-bibloc"
-                        select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/bibliography.xml')"/>
+
+            <!-- Base directory for authority files. Override to point at a different location. -->
+            <xsl:variable name="raw-authority-dir"
+                        select="(document($param-file)//parameter[name = 'authority-dir']/value[. != ''], concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/'))[1]"/>
+            <xsl:param name="authority-dir"
+                        select="if (ends-with($raw-authority-dir, '/')) then $raw-authority-dir else concat($raw-authority-dir, '/')"/>
+            <!-- Individual authority file paths. Default to authority-dir + filename.
+                 Can be overridden individually via global-parameters.xml or as stylesheet params. -->
             <xsl:param name="localbibl"
-                        select="(document($param-file)//parameter[name = 'localbibl']/value[. != ''], $default-bibloc)[1]"/>
+                        select="(document($param-file)//parameter[name = 'localbibl']/value[. != ''], concat($authority-dir, 'bibliography.xml'))[1]"/>
+            <xsl:param name="symbols-file"
+                        select="(document($param-file)//parameter[name = 'symbols-file']/value[. != ''], concat($authority-dir, 'symbols.xml'))[1]"/>
+            <xsl:param name="places-file"
+                        select="(document($param-file)//parameter[name = 'places-file']/value[. != ''], concat($authority-dir, 'places.xml'))[1]"/>
+            <xsl:param name="institutions-file"
+                        select="(document($param-file)//parameter[name = 'institutions-file']/value[. != ''], concat($authority-dir, 'institution.xml'))[1]"/>
+
             <!-- URL template for bibliography links. $1 is replaced by the bibliography entry ID. -->
-            <xsl:param name="bib-link-template" select="'../concordance/bibliography/$1.html'"/>
+            <xsl:param name="bib-link-template"
+                        select="(document($param-file)//parameter[name = 'bib-link-template']/value[. != ''], '../concordance/bibliography/$1.html')[1]"/>
+
             <xsl:param name="ZoteroUorG"
                         select="document($param-file)//parameter[name = 'ZoteroUorG']/value[@on = 'yes']"/>
             <xsl:param name="ZoteroKey"

--- a/htm-teibibl.xsl
+++ b/htm-teibibl.xsl
@@ -274,16 +274,16 @@ bibliography. All examples only cater for book and article.
 	<xsl:template match="t:ptr[@target]">
 		<xsl:param name="parm-edn-structure" tunnel="yes" required="no"/>
 		<xsl:param name="parm-leiden-style" tunnel="yes" required="no"/>
+		<xsl:param name="parm-bibloc" tunnel="yes" required="no"/>
+		<xsl:param name="parm-bib-link-template" tunnel="yes" required="no"/>
 		<xsl:choose>
 			<!-- MODIFIED for SigiDoc by MS 2023-06-16 -->
 			<xsl:when test=" $parm-leiden-style = 'medcyprus' or $parm-edn-structure='inslib' or $parm-edn-structure='sample' or $parm-edn-structure='sigidoc'">
-			 <!-- if you are running this template outside EFES, change the path to the bibliography authority list accordingly -->
-				<xsl:variable name="bibliography-al" select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/bibliography.xml')"/>
 				<xsl:variable name="bibl-ref" select="translate(@target, '#', '')"/>
 				<xsl:choose>
-				 <xsl:when test="doc-available($bibliography-al) = fn:true()">
-				   <xsl:variable name="bibl" select="document($bibliography-al)//t:bibl[@xml:id=$bibl-ref][not(@sameAs)]"/>
-				    <a href="../concordance/bibliography/{$bibl-ref}.html" target="_blank">
+				 <xsl:when test="doc-available($parm-bibloc) = fn:true()">
+				   <xsl:variable name="bibl" select="document($parm-bibloc)//t:bibl[@xml:id=$bibl-ref][not(@sameAs)]"/>
+				    <a href="{replace($parm-bib-link-template, '\$1', $bibl-ref)}" target="_blank">
 				     <xsl:choose>
 					<xsl:when test="$bibl//t:bibl[@type='abbrev']">
 					  <xsl:apply-templates select="$bibl//t:bibl[@type='abbrev'][1]"/>

--- a/htm-teidivapparatus.xsl
+++ b/htm-teidivapparatus.xsl
@@ -242,14 +242,15 @@
     <xsl:param name="parm-edn-structure" tunnel="yes" required="no"/>
     
     <xsl:param name="parm-leiden-style" tunnel="yes" required="no"/>
+    <xsl:param name="parm-bibloc" tunnel="yes" required="no"/>
+    <xsl:param name="parm-bib-link-template" tunnel="yes" required="no"/>
     <xsl:variable name="biblio" select="tokenize(substring-after(., '#'), ' #')"/>
-    
+
     <xsl:choose>
       <xsl:when test="$parm-edn-structure=('inslib', 'sample') or $parm-leiden-style = 'medcyprus'">
-        <xsl:variable name="bibliography-al" select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/bibliography.xml')"/>
+        <xsl:variable name="bibliography-al" select="string($parm-bibloc)"/>
         <xsl:for-each select="$biblio">
           <xsl:variable name="bib" select="normalize-space(.)"/>
-          <!-- if you are running this template outside EFES, change the path to the bibliography authority list accordingly -->
           <xsl:variable name="bibl">
             <xsl:if test="doc-available($bibliography-al)">
               <xsl:sequence select="document($bibliography-al)//t:bibl[@xml:id=$bib][not(@sameAs)]"></xsl:sequence>
@@ -258,7 +259,7 @@
           <xsl:if test="position()=1"><xsl:text> </xsl:text></xsl:if>
           <xsl:choose>
             <xsl:when test="doc-available($bibliography-al) and $bibl">
-              <a href="../concordance/bibliography/{$bib}.html" target="_blank">
+              <a href="{replace($parm-bib-link-template, '\$1', $bib)}" target="_blank">
                 <xsl:choose>
                   <xsl:when test="$bibl//t:bibl[@type='abbrev']">
                     <xsl:apply-templates select="$bibl//t:bibl[@type='abbrev'][1]"/>

--- a/htm-tpl-struct-inslib.xsl
+++ b/htm-tpl-struct-inslib.xsl
@@ -19,6 +19,9 @@
   </xsl:variable>
   
   <xsl:template name="inslib-body-structure">
+    <xsl:param name="parm-bibloc" tunnel="yes" required="no"/>
+    <xsl:param name="parm-bib-link-template" tunnel="yes" required="no"/>
+    <xsl:param name="parm-places-file" tunnel="yes" required="no"/>
     <div id="full-edition">
       <div id="edition-text">
         <xsl:call-template name="inslib-navigation"/>
@@ -239,12 +242,11 @@
               <xsl:if test="@source">
                 <xsl:variable name="source-id" select="substring-after(@source, '#')"/>
                 <p><xsl:text>Translation source: </xsl:text> 
-                  <!-- if you are running this template outside EFES, change the path to the bibliography authority list accordingly -->
-                  <xsl:variable name="bibliography-al" select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/bibliography.xml')"/>
+                  <xsl:variable name="bibliography-al" select="string($parm-bibloc)"/>
                   <xsl:choose>
                     <xsl:when test="doc-available($bibliography-al) = fn:true() and document($bibliography-al)//t:bibl[@xml:id=$source-id][not(@sameAs)]">
                       <xsl:variable name="source" select="document($bibliography-al)//t:bibl[@xml:id=$source-id][not(@sameAs)]"/>
-                      <a href="{concat('../concordance/bibliography/',$source-id,'.html')}" target="_blank">
+                      <a href="{replace($parm-bib-link-template, '\$1', $source-id)}" target="_blank">
                         <xsl:choose>
                           <xsl:when test="$source//t:bibl[@type='abbrev']">
                             <xsl:apply-templates select="$source//t:bibl[@type='abbrev'][1]"/>
@@ -373,15 +375,14 @@
         </xsl:if>
           
         <xsl:if test="$inslib-corpus='IGCyr'">
-          <!-- if you are running this template outside EFES, change the path to the places authority list accordingly -->
-          <xsl:if test="doc-available(concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/places.xml')) = fn:true()">
+          <xsl:if test="doc-available(string($parm-places-file)) = fn:true()">
             <div id="maps">
               <h3>Maps</h3>
               <div class="row map_box">
                 <div id="specific_map" class="map inscription_map"></div>
                 <xsl:variable name="place-name" select="//t:provenance[@type='found'][1]//t:p[1]//t:placeName[@type='ancientFindspot'][1]"/>
                 <xsl:variable name="place-id" select="//t:provenance[@type='found'][1]//t:p[1]//t:placeName[@type='ancientFindspot'][1]/@key"/>
-                <xsl:variable name="places-al" select="document(concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/places.xml'))//t:place[descendant::t:placeName=$place-name][1]"/>
+                <xsl:variable name="places-al" select="document(string($parm-places-file))//t:place[descendant::t:placeName=$place-name][1]"/>
                 <xsl:variable name="counter" select="$places-al//t:note[@type='total_inscriptions']"/>
                 <xsl:variable name="points" select="concat(string-join($place-name, ''), '#', string-join($counter, '') ,'@', substring-after(string-join($place-id, ''), 'slsgazetteer.org/'))"/>
                 <script type="text/javascript">
@@ -542,9 +543,9 @@
   </xsl:template>
   
   <xsl:template match="t:placeName|t:rs|t:repository" mode="inslib-placename">
+    <xsl:param name="parm-institutions-file" tunnel="yes" required="no"/>
     <xsl:variable name="ref-id" select="substring-after(@ref, '#')"/>
-    <!-- if you are running this template outside EFES, change the path to the institutions authority list accordingly -->
-    <xsl:variable name="institutions-list" select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/institution.xml')"/>
+    <xsl:variable name="institutions-list" select="string($parm-institutions-file)"/>
     <xsl:choose>
       <xsl:when test="contains(@ref,'institution.xml') and doc-available($institutions-list) = fn:true() and document($institutions-list)//t:place[@xml:id=$ref-id]//t:idno[1]">
         <a target="_blank" href="{document($institutions-list)//t:place[@xml:id=$ref-id]//t:idno[1]}"><xsl:apply-templates/></a>

--- a/htm-tpl-struct-medcyprus.xsl
+++ b/htm-tpl-struct-medcyprus.xsl
@@ -10,9 +10,10 @@
    <!-- Called from htm-tpl-structure.xsl -->
 
    <xsl:template name="medcyprus-body-structure">
-     <xsl:variable name="editor" select="//t:titleStmt/t:author|//t:titleStmt/t:editor"/>  
-     <!-- if you are running this template outside EFES, change the path to the bibliography authority list accordingly -->
-     <xsl:variable name="bibliography-al" select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/bibliography.xml')"/>
+     <xsl:param name="parm-bibloc" tunnel="yes" required="no"/>
+     <xsl:param name="parm-bib-link-template" tunnel="yes" required="no"/>
+     <xsl:variable name="editor" select="//t:titleStmt/t:author|//t:titleStmt/t:editor"/>
+     <xsl:variable name="bibliography-al" select="string($parm-bibloc)"/>
      
      <p>
        <b>License: </b> <a target="_blank" href="{//t:licence/@target}"><xsl:value-of select="//t:licence"/></a>
@@ -119,7 +120,7 @@
            <xsl:choose>
              <xsl:when test="doc-available($bibliography-al) = fn:true() and document($bibliography-al)//t:bibl[@xml:id=$source-id][not(@sameAs)]">
                <xsl:variable name="source" select="document($bibliography-al)//t:bibl[@xml:id=$source-id][not(@sameAs)]"/>
-               <a href="{concat('../concordance/bibliography/',$source-id,'.html')}" target="_blank">
+               <a href="{replace($parm-bib-link-template, '\$1', $source-id)}" target="_blank">
                  <xsl:choose>
                    <xsl:when test="$source//t:title[@type='short']">
                      <xsl:apply-templates select="$source//t:title[@type='short'][1]"/>
@@ -233,7 +234,7 @@
                <xsl:choose>
                  <xsl:when test="doc-available($bibliography-al) = fn:true() and document($bibliography-al)//t:bibl[@xml:id=$source-id][not(@sameAs)]">
                    <xsl:variable name="source" select="document($bibliography-al)//t:bibl[@xml:id=$source-id][not(@sameAs)]"/>
-                   <a href="../concordance/bibliography/{$source-id}.html" target="_blank">
+                   <a href="{replace($parm-bib-link-template, '\$1', $source-id)}" target="_blank">
                      <xsl:choose>
                        <xsl:when test="$source//t:title[@type='short']">
                          <xsl:apply-templates select="$source//t:title[@type='short'][1]"/>

--- a/start-edition.xsl
+++ b/start-edition.xsl
@@ -123,6 +123,7 @@
                   <xsl:with-param name="parm-css-loc" select="$css-loc" tunnel="yes"/>
                   <xsl:with-param name="parm-bib" select="$bibliography" tunnel="yes"/>
                   <xsl:with-param name="parm-bibloc" select="$localbibl" tunnel="yes"/>
+                  <xsl:with-param name="parm-bib-link-template" select="$bib-link-template" tunnel="yes"/>
                   <xsl:with-param name="parm-zoteroUorG" select="$ZoteroUorG" tunnel="yes"/>
                   <xsl:with-param name="parm-zoteroKey" select="$ZoteroKey" tunnel="yes"/>
                   <xsl:with-param name="parm-zoteroNS" select="$ZoteroNS" tunnel="yes"/>

--- a/start-edition.xsl
+++ b/start-edition.xsl
@@ -124,6 +124,10 @@
                   <xsl:with-param name="parm-bib" select="$bibliography" tunnel="yes"/>
                   <xsl:with-param name="parm-bibloc" select="$localbibl" tunnel="yes"/>
                   <xsl:with-param name="parm-bib-link-template" select="$bib-link-template" tunnel="yes"/>
+                  <xsl:with-param name="parm-symbols-file" select="$symbols-file" tunnel="yes"/>
+                  <xsl:with-param name="parm-places-file" select="$places-file" tunnel="yes"/>
+                  <xsl:with-param name="parm-institutions-file" select="$institutions-file" tunnel="yes"/>
+                  <xsl:with-param name="parm-authority-dir" select="$authority-dir" tunnel="yes"/>
                   <xsl:with-param name="parm-zoteroUorG" select="$ZoteroUorG" tunnel="yes"/>
                   <xsl:with-param name="parm-zoteroKey" select="$ZoteroKey" tunnel="yes"/>
                   <xsl:with-param name="parm-zoteroNS" select="$ZoteroNS" tunnel="yes"/>

--- a/teig.xsl
+++ b/teig.xsl
@@ -22,13 +22,13 @@
       <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
       <xsl:param name="parm-glyph-variant" tunnel="yes" required="no"></xsl:param>
-      
+      <xsl:param name="parm-symbols-file" tunnel="yes" required="no"></xsl:param>
+
       <xsl:choose>
 <!-- **** TEMPORARY FIX FOR MEDCYPRUS TEMPLATE **** -->
          <xsl:when test="$parm-leiden-style=('medcyprus')">
             <xsl:variable name="symbol" select="substring-after(@ref,'#')"/>
-            <!-- if you are running this template outside EFES, change the path to the symbols authority list accordingly -->
-            <xsl:variable name="symbols-al" select="concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/symbols.xml')"/>
+            <xsl:variable name="symbols-al" select="string($parm-symbols-file)"/>
             <xsl:choose>
                <xsl:when test="doc-available($symbols-al) = fn:true() and document($symbols-al)//t:glyph[@xml:id=$symbol]">
                   <xsl:variable name="symbol-id" select="document($symbols-al)//t:glyph[@xml:id=$symbol]"/>
@@ -86,6 +86,7 @@
    <xsl:param name="parm-leiden-style" tunnel="yes" required="no"></xsl:param>
    <xsl:param name="parm-edition-type" tunnel="yes" required="no"></xsl:param>
    <xsl:param name="parm-glyph-variant" tunnel="yes" required="no"></xsl:param>
+   <xsl:param name="parm-authority-dir" tunnel="yes" required="no"/>
    
    <xsl:param name="g"></xsl:param>
    
@@ -132,7 +133,11 @@
          <!--            ref may be a full string, or rather use a prefix, declared in prefixDecl, the xml:id assigned to the glyph may be thus without anchor, and needs to be reconstructed before-->
          <xsl:variable name="parsedRef" select="EDF:refParser(@ref, //t:listPrefixDef)"/>
          
-         <xsl:variable name="externalCharDecl" select="if ($parm-leiden-style='medcyprus') then concat('file:',system-property('user.dir'),'/webapps/ROOT/content/xml/authority/', substring-before($parsedRef, '#')) else substring-before($parsedRef, '#')"/>
+         <xsl:variable name="externalCharDeclFile" select="substring-before($parsedRef, '#')"/>
+         <xsl:variable name="externalCharDecl" select="
+             if ($parm-authority-dir and doc-available(concat($parm-authority-dir, $externalCharDeclFile)))
+             then concat($parm-authority-dir, $externalCharDeclFile)
+             else $externalCharDeclFile"/>
          <xsl:choose>
             <xsl:when test="doc-available($externalCharDecl)">
                <xsl:variable name="externalCharDecldoc" select="doc($externalCharDecl)"/>


### PR DESCRIPTION
Currently, the `t:ptr[@target]` template in `htm-teibibl.xsl` hardcodes two EFES specific values:
- The path to the bibliography authority file (`webapps/ROOT/content/xml/authority/bibliography.xml` relative to `system-property('user.dir')` provided by the Java runtime through EFES/Cocoon
-  The bibliography item link URL pattern (`../concordance/bibliography/{id}.html`).

This makes it hard to use the stylesheets outside of EFES, or with different output site structures that don't follow EFES' patterns.

This PRs uses two configurable params following existing conventions to solve this: 
- The `htm-teibibl` template now uses `$localbibl` to construct the path to the bibliography file
- In `global-varsandparams.xml`, `$localbibl` is set to the currently hardcoded default path via the new `$default-bibloc` variable, ensuring full backwards compatibility without breaking existing projects
- The new `$bib-link-template` param can be used to provide an URL template where `$1` is replaced by the bibliography entry ID. Defaults to current pattern `../concordance/bibliography/$1.html` for backwards compatibility.

It would be great if this could be considered for merging as one step to make the stylesheets more independent from EFES.